### PR TITLE
Fix flake lockfile check

### DIFF
--- a/.github/workflows/flake-lockfile.yml
+++ b/.github/workflows/flake-lockfile.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check changed files
         id: changed
         run: |
-          files=$(gh pr diff "$PR_NUMBER" --name-only)
+          files=$(gh pr diff "$PR_NUMBER" --name-only | xargs -n1 basename | sort -u)
           if [ "$files" = "flake.lock" ]; then
             echo "only_lock_changed=true" | tee -a "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- ensure flake-lockfile workflow recognizes flake.lock in subdirectories by checking basenames

## Testing
- `nix flake archive`
- `nix flake archive ./internal/`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`


------
https://chatgpt.com/codex/tasks/task_e_68b7814939908326aa00e7b1ad755903