### PR TITLE
Migrate merge workflow to ubuntu-slim runner

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.actor == 'dependabot[bot]' && github.repository == 'josh/nurpkgs'
 
     steps:


### PR DESCRIPTION
## Summary
- switch the merge workflow job to use the ubuntu-slim runner

## Testing
- not run (workflow change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692373f9613c8326a3b973998610c17c)